### PR TITLE
Update calls to new Boost API

### DIFF
--- a/src/server/main.cc
+++ b/src/server/main.cc
@@ -134,7 +134,7 @@ int main(int argc, char *argv[])
     return exit_options_error;
   }
 
-  boost::asio::io_service io_service;
+  boost::asio::io_context io_service;
   boost::shared_ptr<MRC1Connection> mrc1_connection;
 
   if (option_map.count("mrc-serial-port")) {
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
     namespace ip = boost::asio::ip;
 
     ip::tcp::endpoint listen_endpoint(
-        ip::address::from_string(option_map["listen-address"].as<std::string>()),
+        ip::make_address_v4(option_map["listen-address"].as<std::string>()),
         option_map["listen-port"].as<unsigned short>());
 
     tcp_server = boost::make_shared<TCPServer>(

--- a/src/server/mrc1_connection.cc
+++ b/src/server/mrc1_connection.cc
@@ -249,7 +249,7 @@ bool MRC1Connection::write_command(const MessagePtr &command,
   }
 
   if (is_silenced()) {
-    m_io_context.post(boost::bind(response_handler, command,
+    asio::post(m_io_context, boost::bind(response_handler, command,
           MessageFactory::make_error_response(proto::ResponseError::SILENCED)));
     return true;
   }
@@ -287,7 +287,7 @@ void MRC1Connection::handle_write_command(const boost::system::error_code &ec, s
         : proto::ResponseError::COM_ERROR);
     response->mutable_mrc_status()->set_info(ec.message());
 
-    m_io_context.post(boost::bind(m_current_response_handler, m_current_command, response));
+    asio::post(m_io_context, boost::bind(m_current_response_handler, m_current_command, response));
     m_current_command.reset();
     m_current_response_handler = 0;
     stop(ec);
@@ -350,7 +350,7 @@ void MRC1Connection::handle_command_response_read(const boost::system::error_cod
           << proto::Message::Type_Name(m_reply_parser.get_response_message()->type());
 
         /* Parsing complete. Call the response handler. */
-        m_io_context.post(boost::bind(m_current_response_handler, m_current_command,
+        asio::post(m_io_context, boost::bind(m_current_response_handler, m_current_command,
               m_reply_parser.get_response_message()));
 
         m_current_command.reset();
@@ -365,7 +365,7 @@ void MRC1Connection::handle_command_response_read(const boost::system::error_cod
         ec == errc::operation_canceled ? proto::ResponseError::COM_TIMEOUT : proto::ResponseError::COM_ERROR);
     response->mutable_mrc_status()->set_info(ec.message());
 
-    m_io_context.post(boost::bind(m_current_response_handler, m_current_command, response));
+    asio::post(m_io_context, boost::bind(m_current_response_handler, m_current_command, response));
     m_current_command.reset();
     m_current_response_handler = 0;
     stop(ec);
@@ -557,9 +557,8 @@ void MRC1TCPConnection::start_impl(ErrorCodeCallback completion_handler)
     BOOST_LOG_SEV(m_log, log::lvl::info) << "Connecting to "
       << m_host << ":" << m_service;
 
-    tcp::resolver::query query(m_host, m_service);
-    tcp::resolver::iterator endpoint_iter(m_resolver.resolve(query));
-    asio::connect(m_socket, endpoint_iter);
+    auto endpoints = m_resolver.resolve(m_host, m_service);
+    asio::connect(m_socket, endpoints);
     m_socket.set_option(asio::ip::tcp::no_delay(true));
 
     completion_handler(boost::system::error_code(), {});

--- a/src/server/mrc1_connection.h
+++ b/src/server/mrc1_connection.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/function.hpp>

--- a/src/server/mrc1_request_queue.cc
+++ b/src/server/mrc1_request_queue.cc
@@ -56,7 +56,7 @@ void MRC1RequestQueue::try_send_mrc1_request()
   if (!m_mrc1_connection->is_running()) {
     if (m_mrc1_connection->get_status() == proto::MRCStatus::INITIALIZING) {
       BOOST_LOG_SEV(m_log, log::lvl::debug) << "MRC still initializing. Retrying later";
-      m_retry_timer.expires_from_now(get_retry_timeout());
+      m_retry_timer.expires_after(get_retry_timeout());
       m_retry_timer.async_wait(boost::bind(&MRC1RequestQueue::handle_retry_timer, this, _1));
       return;
     }

--- a/src/server/mrc_comm.cc
+++ b/src/server/mrc_comm.cc
@@ -57,7 +57,7 @@ void MRCComm::finish_read_until_prompt(const boost::system::error_code &ec, std:
     data = std::string(asio::buffers_begin(buffers), asio::buffers_end(buffers));
   }
 
-  m_io.post(boost::bind(m_read_handler, ec, data));
+  asio::post(m_io, boost::bind(m_read_handler, ec, data));
 
   m_asio_buf.consume(m_asio_buf.size());
   m_busy = false;
@@ -110,7 +110,7 @@ void MRCComm::handle_write(std::string::const_iterator it, boost::system::error_
 void MRCComm::finish_write(std::string::const_iterator it, boost::system::error_code ec)
 {
   m_timer.cancel();
-  m_io.post(boost::bind(m_write_handler, ec, it - m_str_buf.begin()));
+  asio::post(m_io, boost::bind(m_write_handler, ec, it - m_str_buf.begin()));
   m_busy = false;
   m_write_handler = 0;
   m_str_buf.clear();
@@ -140,7 +140,7 @@ void MRCComm::finish_read(const boost::system::error_code &ec)
     << "MRCComm::finish_read: ec=" << ec.message();
 
   m_timer.cancel();
-  m_io.post(boost::bind(m_read_handler,
+  asio::post(m_io, boost::bind(m_read_handler,
         ec == boost::system::errc::operation_canceled ? boost::system::error_code() : ec,
         m_str_buf));
   m_busy = false;

--- a/src/server/mrc_comm.h
+++ b/src/server/mrc_comm.h
@@ -2,6 +2,7 @@
 #define UUID_520d7afb_0f07_4e30_b766_561a3671ca6f
 
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/src/server/tcp_connection.cc
+++ b/src/server/tcp_connection.cc
@@ -14,7 +14,7 @@ namespace asio = boost::asio;
 namespace mesycontrol
 {
 
-TCPConnection::TCPConnection(boost::asio::io_service &io_service, TCPConnectionManager &manager)
+TCPConnection::TCPConnection(boost::asio::io_context &io_service, TCPConnectionManager &manager)
   : m_socket(io_service)
   , m_connection_manager(manager)
   , m_read_size(0)

--- a/src/server/tcp_connection.h
+++ b/src/server/tcp_connection.h
@@ -20,7 +20,7 @@ class TCPConnection
   , private boost::noncopyable
 {
   public:
-    explicit TCPConnection(boost::asio::io_service &io_service, TCPConnectionManager &manager);
+    explicit TCPConnection(boost::asio::io_context &io_service, TCPConnectionManager &manager);
     ~TCPConnection();
 
     void start();

--- a/src/server/tcp_server.cc
+++ b/src/server/tcp_server.cc
@@ -6,7 +6,7 @@ namespace mesycontrol
 {
 
 TCPServer::TCPServer(
-    boost::asio::io_service &io_service,
+    boost::asio::io_context &io_service,
     boost::asio::ip::tcp::endpoint endpoint,
     TCPConnectionManager &connection_manager)
   : m_io_service(io_service)

--- a/src/server/tcp_server.h
+++ b/src/server/tcp_server.h
@@ -14,7 +14,7 @@ namespace mesycontrol
 class TCPServer: private boost::noncopyable
 {
   public:
-    explicit TCPServer(boost::asio::io_service &io_service,
+    explicit TCPServer(boost::asio::io_context &io_service,
         boost::asio::ip::tcp::endpoint endpoint,
         TCPConnectionManager &connection_manager);
     ~TCPServer();
@@ -26,7 +26,7 @@ class TCPServer: private boost::noncopyable
     void handle_accept(const boost::system::error_code &ec);
 
 
-    boost::asio::io_service &m_io_service;
+    boost::asio::io_context &m_io_service;
     boost::asio::ip::tcp::acceptor m_acceptor;
     TCPConnectionManager &m_connection_manager;
     TCPConnectionPtr m_new_connection;


### PR DESCRIPTION
This solves #2 in a minimal way, some deprecated objects such as `deadline_timer` are kept for now.